### PR TITLE
Updating duration parameter in the pod failure experiment

### DIFF
--- a/src/python/chaosmesh/experiments/base/k8s/podfault/__init__.py
+++ b/src/python/chaosmesh/experiments/base/k8s/podfault/__init__.py
@@ -34,7 +34,8 @@ class PodChaos(ChaosExperiment, ABC):
             "mode": "all",
             "labels": {},
             "pods": {},
-            "value": ""
+            "value": "",
+            "duration": ""
         }
 
     @property
@@ -87,5 +88,6 @@ class PodChaos(ChaosExperiment, ABC):
             "mode": self.kwargs.get('mode'),
             "value": self.kwargs.get('value'),
             "action": self.kwargs.get('action'),
-            "gracePeriod": self.kwargs.get('gracePeriod')
+            "gracePeriod": self.kwargs.get('gracePeriod'),
+            "duration": self.kwargs.get('duration')
         }


### PR DESCRIPTION
```
kind: PodChaos
apiVersion: chaos-mesh.org/v1alpha1
metadata:
  namespace: vmware-cric
  name: energy-saving-pod-failure-870435
spec:
  selector:
    namespaces:
      - vmware-cric
    labelSelectors:
      rapp_cr: energy-saving
  mode: all
  action: pod-failure
  duration: 1m <------- Introducing this parameter with the MR
  gracePeriod: 0
```


Adding the `duration` parameter in the spec to simulate pod failure experiment for a particular duration.